### PR TITLE
Removed num parameter from query

### DIFF
--- a/src/Engine/GoogleSearch.php
+++ b/src/Engine/GoogleSearch.php
@@ -97,7 +97,6 @@ class GoogleSearch extends SearchEngine
             'client' => 'navclient', // probably useless
             'gbv' => 1, // no javascript
             'complete' => 0, // 0 to disable instant search and enable more than 10 results
-            'num' => $results_per_page, // number of results
             'pws' => 0, // do not personalize my search results
             'nfpr' => 1, // do not auto correct my search queries
             'ie' => 'utf-8',


### PR DESCRIPTION
Google has published new update to prevent scraping. The most suitable choice is removing num parameter from query.
https://2captcha.com/blog/google-sepr-recaptcha-june-2022